### PR TITLE
Updates CLI to expect organization to be passed in.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This tool can be used to generate a Markdown File containing the last 7 days of 
 
 ### Github Access Token
 
-You will need a Github access token that has access to the `roirevolution` organization.
+You will need a Github access token that has access to the organization you are fetching pull request information for.
 
 You can generate this token in [your Github setting](https://github.com/settings/tokens).
 
@@ -20,10 +20,10 @@ This `access_token` is accessed via an environmental variable. You can `export` 
 ```bash
 # Set the environmental variable
 export GITHUB_ACCESS_TOKEN="MY_TOKEN"
-./weekly_summary
+./weekly_summary ORGANIZATION_NAME
 
 # Set at run time
-GITHUB_ACCESS_TOKEN=MY_TOKEN ./weekly_summary 
+GITHUB_ACCESS_TOKEN=MY_TOKEN ./weekly_summary ORGANIZATION_NAME
 ```
 
 This will print the Weekly Summary to `stdout`. This script is most useful to run and redirect ourput to a file

--- a/lib/issue_requester.ex
+++ b/lib/issue_requester.ex
@@ -1,8 +1,8 @@
 defmodule WeeklySummary.IssueRequester do
-  def issues do
+  def issues(organization) do
     client = Tentacat.Client.new(%{access_token: System.get_env("GITHUB_ACCESS_TOKEN")})
 
-    Tentacat.Repositories.list_orgs("roirevolution", client)
+    Tentacat.Repositories.list_orgs(organization, client)
     |> extract_names
     |> Task.async_stream(__MODULE__, :fetch_closed_pull_requests, [client])
     |> Stream.filter(fn({status, _values}) -> status == :ok end)

--- a/lib/main.ex
+++ b/lib/main.ex
@@ -2,8 +2,16 @@ defmodule WeeklySummary.Main do
   alias WeeklySummary.IssueRequester
   alias WeeklySummary.Report
 
-  def main(_args) do
-    IssueRequester.issues
-    |> Report.generate
+  def main(args) do
+    {_parsed, org, _} = OptionParser.parse(args)
+
+    case length(org) do
+      0 -> exit("Organization name required")
+      1 ->
+        org
+        |> IssueRequester.issues
+        |> Report.generate
+      _ -> exit("Only one organization may be specified")
+    end
   end
 end


### PR DESCRIPTION
This closes #1 

Rather than only working for the `roirevolution` organization, the CLI has been
updated to take in an organization name as an argument.